### PR TITLE
Prevent webserver/web liveness probe from failing

### DIFF
--- a/.k8s/base/webserver/web/deployment.yaml
+++ b/.k8s/base/webserver/web/deployment.yaml
@@ -24,6 +24,13 @@ spec:
           httpGet:
             path: /api/healthz
             port: 8080
+        livenessProbe:
+          httpGet:
+            path: /api/healthz
+            port: 8080
+          timeoutSeconds: 30
+          failureThreshold: 5
+          periodSeconds: 60
         env:
         - name: PORT
           value: "8080"


### PR DESCRIPTION
Make liveness probe tolerate very slow no-op response times before terminating the process. Increase memory limit according to observed consumption in production.