### PR TITLE
Configure DBpedia Spotlight dependency

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,5 @@
+# Use the Official DBpedia Spotlight API ...
+DBPEDIA_SPOTLIGHT_URL="https://api.dbpedia-spotlight.org/en/annotate"
+
+# ... or a custom  DBpedia Spotlight API endpoint
+#DBPEDIA_SPOTLIGHT_URL="https://example.org/rest/annotate"

--- a/.k8s/base/coursemapper-kg/concept-map/deployment.yaml
+++ b/.k8s/base/coursemapper-kg/concept-map/deployment.yaml
@@ -32,6 +32,9 @@ spec:
           value: postgres://postgres:password@$(WP_PG_SERVICE):5432
         - name: WIKIPEDIA_FALLBACK
           value: "false"
+        envFrom:
+        - configMapRef:
+            name: dbpedia-spotlight
         resources:
           requests:
             cpu: 100m

--- a/.k8s/base/kustomization.yaml
+++ b/.k8s/base/kustomization.yaml
@@ -19,6 +19,9 @@ configMapGenerator:
 - name: ingress
   literals:
   - host=example.org
+- name: dbpedia-spotlight
+  literals: []
+  # - DBPEDIA_SPOTLIGHT_URL=https://example.org/rest/annotate
 
 images:
 - name: coursemapper-kg-concept-map

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CourseMapper is a collaborative course annotation and analytics platform that fo
 
 ## 🚀 Get Started
 
-#### Live instances
+#### 🌎 Live instances
 
 - Production:
   [coursemapper.de](https://coursemapper.de/)
@@ -19,14 +19,14 @@ CourseMapper is a collaborative course annotation and analytics platform that fo
 
 *Note:* Stable [releases](https://github.com/ude-soco/CourseMapper-webserver/releases) are currently not running in production.
 
-#### Build and run
+#### 🐳 Compose
 
-- `make up` to run the application using _Docker Compose_
-- `make tilt` to automatically rebuild during development using _Tilt_
-- `make mounted` to run processes using _Docker Compose_, but mount source code from host machine
-- see the manual below to install dependencies and run processes _locally, without containers_
-
-Visit the [proxy service on port 8000](http://localhost:8000/) to use the application.
+1. Set up `.env` file (see `.env.dist`)
+2. Build and run
+   - `make up` to run the application using _Docker Compose_
+   - `make tilt` to automatically rebuild during development using _Tilt_
+   - `make mounted` to run processes using _Docker Compose_, but mount source code from host machine
+3. Visit the [proxy service on port 8000](http://localhost:8000/) to use the application.
 
 ## 🖥️ Application stack
 

--- a/coursemapper-kg/concept-map/compose.yaml
+++ b/coursemapper-kg/concept-map/compose.yaml
@@ -14,6 +14,7 @@ services:
       PIPELINES: concept-map
       WIKIPEDIA_DATABASE_CONNECTION_STRING: "postgres://postgres:password@wp-pg:5432/"
       WIKIPEDIA_FALLBACK: false
+      DBPEDIA_SPOTLIGHT_URL: ${DBPEDIA_SPOTLIGHT_URL}
     depends_on:
       neo4j:
         condition: service_healthy

--- a/coursemapper-kg/concept-map/example.env
+++ b/coursemapper-kg/concept-map/example.env
@@ -1,9 +1,15 @@
-WIKIPEDIA_DATABASE_CONNECTION_STRING=
+PIPELINES=concept-map,modify-graph,expand-material
+
 NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=1234qwer!
+
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_DATABASE=0
 REDIS_PASSWORD=
-PIPELINES=concept-map,modify-graph,expand-material
+
+WIKIPEDIA_DATABASE_CONNECTION_STRING=
+
+DBPEDIA_SPOTLIGHT_URL="https://api.dbpedia-spotlight.org/en/annotate" # official DBpedia Spotlight API ...
+#DBPEDIA_SPOTLIGHT_URL="https://example.org/rest/annotate"             # ... or custom instance

--- a/coursemapper-kg/concept-map/src/config.py
+++ b/coursemapper-kg/concept-map/src/config.py
@@ -19,9 +19,7 @@ class Config:
     NEO4J_PASSWORD = os.getenv('NEO4J_PASSWORD', 'password')
     NEO4J_SAVE_TO_DB = os.getenv('NEO4J_SAVE_TO_DB', 'true').lower() == 'true'
 
-    DBPEDIA_SPOTLIGHT_URL = os.getenv('DBPEDIA_SPOTLIGHT_URL', 'https://dbpedia-spotlight-en.soco.ude.systems/rest/annotate')
-    # Uncomment the line below to use the official DBpedia Spotlight API
-    # DBPEDIA_SPOTLIGHT_URL = os.getenv('DBPEDIA_SPOTLIGHT_URL', 'https://api.dbpedia-spotlight.org/en/annotate')
+    DBPEDIA_SPOTLIGHT_URL = os.getenv('DBPEDIA_SPOTLIGHT_URL')
     DBPEDIA_SPOTLIGHT_CONFIDENCE = float(os.getenv('DBPEDIA_SPOTLIGHT_CONFIDENCE', '0.35'))
     DBPEDIA_SPOTLIGHT_SUPPORT = int(os.getenv('DBPEDIA_SPOTLIGHT_SUPPORT', '5'))
 


### PR DESCRIPTION
Make DBpedia Spotlight API endpoint configurable, so that a custom instance can be used in local development, Compose, and K8s environments.