### PR TITLE
Update package installation to Debian Bookworm

### DIFF
--- a/coursemapper-kg/wp-pg/Dockerfile
+++ b/coursemapper-kg/wp-pg/Dockerfile
@@ -1,16 +1,12 @@
 # syntax=docker/dockerfile:1.15
 FROM postgres:16
 
-# APT requires archive URLs
-COPY debian/stretch.sources.list /etc/apt/sources.list
-
 # Install dependencies
 ENV RUNTIME_DEPS="ca-certificates rclone"
 RUN --mount=type=cache,sharing=private,target=/var/cache/apt \
     --mount=type=cache,sharing=private,target=/var/lib/apt <<EOF
   rm -f /etc/apt/apt.conf.d/docker-clean
   echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 112695A0E562B32A &&
   DEBIAN_FRONTEND=noninteractive apt-get update -q &&
   apt-get install -qq --no-install-recommends -o=Dpkg::Use-Pty=0 $RUNTIME_DEPS
 EOF

--- a/coursemapper-kg/wp-pg/debian/stretch.sources.list
+++ b/coursemapper-kg/wp-pg/debian/stretch.sources.list
@@ -1,3 +1,0 @@
-deb http://archive.debian.org/debian/ stretch main contrib non-free
-deb http://archive.debian.org/debian/ stretch-proposed-updates main contrib non-free
-deb http://archive.debian.org/debian-security stretch/updates main contrib non-free


### PR DESCRIPTION
postgres:16 image no longer requires Debian archive hacks